### PR TITLE
Fix an exception when deleting VLans

### DIFF
--- a/nixos_compose/driver/vlan.py
+++ b/nixos_compose/driver/vlan.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 import io
 import os
 import pty
@@ -18,7 +19,7 @@ class VLan:
     socket_dir: Path
 
     process: subprocess.Popen
-    slirpvde_process: subprocess.Popen
+    slirpvde_process: Optional[subprocess.Popen]
     pid: int
     fd: io.TextIOBase
 
@@ -29,6 +30,7 @@ class VLan:
         self.ctx = ctx
         self.nr = nr
         self.socket_dir = tmp_dir / f"vde{self.nr}.ctl"
+        self.slirpvde_process = None
 
         # TODO: don't side-effect environment here
         os.environ[f"QEMU_VDE_SOCKET_{self.nr}"] = str(self.socket_dir)
@@ -105,5 +107,5 @@ class VLan:
         rootlog.info(f"kill vlan (pid {self.pid})")
         self.fd.close()
         self.process.terminate()
-        if self.slirpvde_process:
+        if self.slirpvde_process is not None:
             self.slirpvde_process.terminate()


### PR DESCRIPTION
I encountered this exception when running `nxc start -f vm`.

```
Platform detection:
      no particular platform detected, local mode will be used
start vlan
cannot start vde_switch
kill vlan (pid 36093)
Exception ignored in: <function VLan.__del__ at 0x7ffff5cfc700>
Traceback (most recent call last):
  File "/nix/store/b49499gzjim5j112pz7rbn9d6vkkwv0i-python3.10-nxc-locale/lib/python3.10/site-packages/nixos_compose/driver/vlan.py", line 108, in __del__
    if self.slirpvde_process:
AttributeError: 'VLan' object has no attribute 'slirpvde_process'
```

This patch fixes it.