### PR TITLE
VM flavor: only specify -groups for vde_switch if needed

### DIFF
--- a/nixos_compose/driver/vlan.py
+++ b/nixos_compose/driver/vlan.py
@@ -51,17 +51,15 @@ class VLan:
             subprocess.call("sudo true", shell=True)
             vde_cmd = ["sudo"] + vde_cmd + ["-tap", "tap0"]
 
-        group_users = "users"
-        if ctx.platform and ctx.platform.group_users:
-            group_users = ctx.platform.group_users
         vde_cmd = vde_cmd + [
             "-s",
             self.socket_dir,
             "-mod",
             "0770",
-            "-group",
-            group_users,
         ]
+
+        if ctx.platform and ctx.platform.group_users:
+            vde_cmd = vde_cmd + [ "-group", ctx.platform.group_users ]
 
         self.process = subprocess.Popen(
             vde_cmd,


### PR DESCRIPTION
`nxc start -f vm` was only working on NixOS, because most other Linux distributions don't have a `users` group by default. When `-group` is not specified, `vde_switch` uses the "main" group of the current user (which should be `users` on NixOS).

This patch has been tested on ArchLinux, Ubuntu, Linux Mint and NixOS.