### PR TITLE
Enable X11 libraries

### DIFF
--- a/nix/flavours/shared/common.nix
+++ b/nix/flavours/shared/common.nix
@@ -144,8 +144,6 @@ with lib; {
   # misc
   key = "no-manual";
 
-  environment.noXlibs = mkDefault true;
-
   documentation.enable = mkDefault false;
 
   documentation.nixos.enable = mkDefault false;


### PR DESCRIPTION
This option was turned off to limit output size.
However, if X11 libraries are not present, a lot of packages are compiled differently (additional dependencies, build flags or patches) and thus there were a lot of cache miss.
Enabling it back by default allows for faster builds.