### PR TITLE
Fix helper nix install

### DIFF
--- a/nixos_compose/actions.py
+++ b/nixos_compose/actions.py
@@ -890,7 +890,7 @@ def get_nix_command(ctx):
 # get Nix-static
 def install_nix_static(
     ctx,
-    version="2.10.3",
+    version="2.20.5",
     archi="x86_64",
     local_bin_path=f"{os.environ['HOME']}/.local/bin",
 ):
@@ -904,7 +904,7 @@ def install_nix_static(
     nix_path = op.join(local_bin_path, "nix")
 
     urllib.request.urlretrieve(
-        f"https://gitlab.inria.fr/nixos-compose/nix-static/-/raw/main/bin/nix-{version}-{archi}-unknown-linux-musl",
+        f"https://gitlab.inria.fr/nixos-compose/nix-static/-/raw/main/bin/nix-{version}-{archi}-linux-static",
         nix_path,
     )
 

--- a/nixos_compose/actions.py
+++ b/nixos_compose/actions.py
@@ -890,7 +890,7 @@ def get_nix_command(ctx):
 # get Nix-static
 def install_nix_static(
     ctx,
-    version="2.10.3",
+    version="2.20.5",
     archi="x86_64",
     local_bin_path=f"{os.environ['HOME']}/.local/bin",
 ):


### PR DESCRIPTION
Maybe this is already on dev branch, so I apologise if it is the case.

Recently I have http 404 using helper install-nix. 

This will fix the default values for version and file to fetch in this  [nix-static](https://gitlab.inria.fr/nixos-compose/nix-static/-/blob/main/bin/nix-2.20.5-x86_64-linux-static?ref_type=heads) inria repo, there is also a 2.21.0 version but the latest commit inserts 2.20.5 so that is what i used and tested.

Tested on grid5000 grenoble frontale. 